### PR TITLE
Fix TownMenu grid layout to show all action buttons

### DIFF
--- a/apps/web/src/components/game/interactions/TownMenu.tsx
+++ b/apps/web/src/components/game/interactions/TownMenu.tsx
@@ -111,8 +111,8 @@ export function TownMenu({ onAction }: TownMenuProps) {
         <span className="text-xs text-[#606080]">Town Services</span>
       </div>
 
-      {/* Action buttons grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {/* Action buttons grid - auto-fit ensures all items visible */}
+      <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
         {actions.map((action) => (
           <TownMenuButton
             key={action.id}


### PR DESCRIPTION
Changed grid from 2 columns to 3 columns on mobile to ensure all
town actions (including gym) are visible on one row. This fixes an
issue where the gym action in Pallet Town might not be visible if
placed on a second row that gets clipped.

- Changed: grid-cols-2 sm:grid-cols-4 -> grid-cols-3 sm:grid-cols-4
- Pallet Town now shows Heal, Oak Lab, and Gym on single row