### PR TITLE
Fix friend zone display showing user's own zone

### DIFF
--- a/apps/game-server/src/hub.ts
+++ b/apps/game-server/src/hub.ts
@@ -544,6 +544,9 @@ export class GameHub {
     for (const [, otherClient] of this.clients) {
       if (!otherClient.session) continue
 
+      // Skip self - don't notify the player who moved about their own zone change
+      if (otherClient.session.player.id === playerId) continue
+
       // Check if this online user is a friend
       const isFriend = friends.some(
         f => f.friend_player_id === otherClient.session!.player.id ||


### PR DESCRIPTION
The notifyFriendsOfZoneChange function was iterating over ALL clients including the player who moved. Since the friends list contains entries where player_id OR friend_player_id could be the mover's own ID, the mover would receive their own zone update and incorrectly apply it to their friends list, overwriting friends' actual zones with their own.

Fix: Skip self when broadcasting friend zone updates.